### PR TITLE
fix:fix wrong node

### DIFF
--- a/collector/utils.go
+++ b/collector/utils.go
@@ -13,8 +13,6 @@ func cutNodeName(nodeName string) string {
 
 	if ip, err := netip.ParseAddr(slice[1]); err == nil {
 		return ip.String()
-	} else if pos := strings.IndexRune(slice[1], '.'); pos != 0 {
-		return slice[1][:pos]
 	}
 	return slice[1]
 }


### PR DESCRIPTION
fix wrong node,when the emqx node host is FQDN,for example:

~~~shell
['emqx@node1.emqx.com','emqx@node1.emqx.io']
~~~